### PR TITLE
Fix memory API path

### DIFF
--- a/project/src/api/memoriesApi.ts
+++ b/project/src/api/memoriesApi.ts
@@ -187,7 +187,7 @@ class MemoriesApi {
         } : {})
       };
       
-      const response = await fetch(`${this.baseUrl}/cloudinary/create-memory`, {
+      const response = await fetch(`${this.baseUrl}/cloudinary/memory`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- adjust endpoint used by `addMilestone` to match backend API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6879f22f39608333909ed2308bc588bb